### PR TITLE
Separate scene widget to own module

### DIFF
--- a/src/ndevio/widgets/__init__.py
+++ b/src/ndevio/widgets/__init__.py
@@ -1,5 +1,6 @@
 """Widgets for ndevio package."""
 
 from ._plugin_install_widget import PluginInstallerWidget
+from ._scene_widget import DELIMITER, nImageSceneWidget
 
-__all__ = ["PluginInstallerWidget"]
+__all__ = ["PluginInstallerWidget", "nImageSceneWidget", "DELIMITER"]

--- a/src/ndevio/widgets/_scene_widget.py
+++ b/src/ndevio/widgets/_scene_widget.py
@@ -1,0 +1,127 @@
+"""Widget for selecting scenes from multi-scene image files.
+
+This widget is used when opening files that contain multiple scenes/series.
+It allows users to select which scene(s) to open in the viewer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from magicgui.widgets import Container, Select
+from ndev_settings import get_settings
+
+if TYPE_CHECKING:
+    import napari
+    from napari.types import PathLike
+
+    from ..nimage import nImage
+
+logger = logging.getLogger(__name__)
+
+DELIMITER = " :: "
+
+
+class nImageSceneWidget(Container):
+    """
+    Widget to select a scene from a multi-scene file.
+
+    Parameters
+    ----------
+    viewer : napari.viewer.Viewer
+        The napari viewer instance.
+    path : PathLike
+        Path to the file.
+    img : nImage
+        The nImage instance.
+    in_memory : bool
+        Whether the image should be added in memory.
+
+    Attributes
+    ----------
+    viewer : napari.viewer.Viewer
+        The napari viewer instance.
+    path : PathLike
+        Path to the file.
+    img : nImage
+        The nImage instance.
+    in_memory : bool
+        Whether the image should be added in memory.
+    settings : Settings
+        The settings instance.
+    scenes : list
+        List of scenes in the image.
+    _scene_list_widget : magicgui.widgets.Select
+        Widget to select a scene from a multi-scene file.
+
+    Methods
+    -------
+    open_scene
+        Opens the selected scene(s) in the viewer.
+
+    """
+
+    def __init__(
+        self,
+        viewer: napari.viewer.Viewer,
+        path: PathLike,
+        img: nImage,
+        in_memory: bool,
+    ):
+        """
+        Initialize the nImageSceneWidget.
+
+        Parameters
+        ----------
+        viewer : napari.viewer.Viewer
+            The napari viewer instance.
+        path : PathLike
+            Path to the file.
+        img : nImage
+            The nImage instance.
+        in_memory : bool
+            Whether the image should be added in memory.
+
+        """
+        super().__init__(labels=False)
+        self.max_height = 200
+        self.viewer = viewer
+        self.path = path
+        self.img = img
+        self.in_memory = in_memory
+        self.settings = get_settings()
+        self.scenes = [
+            f"{idx}{DELIMITER}{scene}"
+            for idx, scene in enumerate(self.img.scenes)
+        ]
+
+        self._init_widgets()
+        self._connect_events()
+
+    def _init_widgets(self):
+        self._scene_list_widget = Select(
+            value=None,
+            nullable=True,
+            choices=self.scenes,
+        )
+        self.append(self._scene_list_widget)
+
+    def _connect_events(self):
+        self._scene_list_widget.changed.connect(self.open_scene)
+
+    def open_scene(self) -> None:
+        """Open the selected scene(s) in the viewer."""
+        if self.settings.ndevio_Reader.clear_layers_on_new_scene:
+            self.viewer.layers.clear()
+
+        for scene in self._scene_list_widget.value:
+            if scene is None:
+                continue
+            # Use scene indexes to cover for duplicate names
+            scene_index = int(scene.split(DELIMITER)[0])
+            self.img.set_scene(scene_index)
+            img_data = self.img.get_napari_image_data(in_memory=self.in_memory)
+            img_meta = self.img.get_napari_metadata()
+
+            self.viewer.add_image(img_data.data, **img_meta)


### PR DESCRIPTION
This pull request refactors the implementation of the scene selection widget for multi-scene image files in the `ndevio` package. The main change is moving the `nImageSceneWidget` and its related constant `DELIMITER` from `src/ndevio/_napari_reader.py` to a new dedicated module, improving code organization and modularity. The widget import paths are updated accordingly throughout the codebase.

**Widget refactoring and modularization:**

* Moved the `nImageSceneWidget` class and the `DELIMITER` constant from `src/ndevio/_napari_reader.py` to a new module `src/ndevio/widgets/_scene_widget.py`, providing better separation of concerns and maintainability. [[1]](diffhunk://#diff-a1495b29f6e07c8278a427f1ad3f4b1033da9353d263c050f0c8d9ac1b2aeebdL221-L324) [[2]](diffhunk://#diff-95cabfe66da31c6e66e52a789bb410721325aa105aacbc8a75b79194a9974351R1-R127)
* Updated the import statements in `src/ndevio/_napari_reader.py` to import `DELIMITER` and `nImageSceneWidget` from the new module.
* Added `DELIMITER` and `nImageSceneWidget` to the `__all__` list in `src/ndevio/widgets/__init__.py` for proper package exports.
* Removed unused imports and cleaned up type checking code in `src/ndevio/_napari_reader.py`.