### PR TITLE
Fix deploy steps

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -85,9 +85,7 @@ jobs:
           python-version: "3.13"
       - name: Build package
         run: |
-          uv venv --python 3.13
-          uv pip install hatch
-          git tag
-          hatch build
+          uv pip install --upgrade hatch
+          uv run hatch build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates the Python package build process in the GitHub Actions workflow to use a more streamlined approach with `uv` and `hatch`. The changes improve the build step by removing unnecessary commands and ensuring dependencies are upgraded before building.

Build process improvements:

* The build step now upgrades `hatch` via `uv pip install --upgrade hatch` instead of creating a new virtual environment and installing `hatch` separately, simplifying dependency management.
* The package is built using `uv run hatch build`, which runs the build command directly, removing the need for explicit virtual environment creation and tag listing.
