### PR TITLE
switch to hynek build and inspect

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -52,25 +52,28 @@ jobs:
       - name: Coverage
         uses: codecov/codecov-action@v5
 
+  build-and-inspect-package:
+    name: Build & inspect package.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hynek/build-and-inspect-python-package@v2
+
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
     # and requires that you have put your twine API key in your
     # github secrets (see readme for details)
-    needs: [test]
+    needs: [test, build-and-inspect-package]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - name: Set up Python
-        uses: astral-sh/setup-uv@v7
+      - name: Download built artifact to dist/
+        uses: actions/download-artifact@v6
         with:
-          python-version: "3.13"
-          enable-cache: false
-      - name: Build package
-        run: |
-          python -m pip install build
-          python -m build
+          name: Packages
+          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve the build and deployment process for the package. The main changes are the introduction of a dedicated build and inspection job and the simplification of the deployment step to use pre-built artifacts.

**CI/CD workflow improvements:**

* Added a new `build-and-inspect-package` job that checks out the code and uses the `hynek/build-and-inspect-python-package` action to build and inspect the package. (.github/workflows/test_and_deploy.yml)
* Updated the `deploy` job to depend on both the `test` and `build-and-inspect-package` jobs, ensuring that deployment only happens after successful testing and package inspection. (.github/workflows/test_and_deploy.yml)
* Simplified the deployment process by removing redundant build steps and instead downloading the pre-built package artifact for publishing to PyPI. (.github/workflows/test_and_deploy.yml)