### PR TITLE
Add axis_labels and units, refactor to using properties in `nImage`

### DIFF
--- a/src/ndevio/widgets/_scene_widget.py
+++ b/src/ndevio/widgets/_scene_widget.py
@@ -123,7 +123,7 @@ class nImageSceneWidget(Container):
             self.img.set_scene(scene_index)
 
             # Clear cached data so new scene is loaded
-            self.img._napari_layer_data = None
+            self.img._layer_data = None
 
             # Get layer tuples and add to viewer using napari's Layer.create()
             from napari.layers import Layer

--- a/tests/test_nimage.py
+++ b/tests/test_nimage.py
@@ -27,10 +27,10 @@ def test_nImage_init(resources_dir: Path):
     assert img.reader is not None
     # Shape is (T, C, Z, Y, X) = (1, 2, 60, 66, 85)
     assert img.data.shape == (1, 2, 60, 66, 85)
-    # napari_layer_data should not be loaded until accessed
-    assert img._napari_layer_data is None
+    # layer_data should not be loaded until accessed
+    assert img._layer_data is None
     # Accessing the property triggers lazy loading
-    assert img.napari_layer_data is not None
+    assert img.layer_data is not None
 
 
 def test_nImage_ome_reader(resources_dir: Path):
@@ -115,11 +115,11 @@ def test_nImage_determine_in_memory_large_file(resources_dir: Path):
 def test_get_layer_data(resources_dir: Path):
     """Test loading napari layer data in memory."""
     img = nImage(resources_dir / CELLS3D2CH_OME_TIFF)
-    img._load_napari_layer_data()
-    # napari_layer_data will be squeezed
+    img._load_layer_data()
+    # layer_data will be squeezed
     # Original shape (1, 2, 60, 66, 85) -> (2, 60, 66, 85)
-    assert img.napari_layer_data.shape == (2, 60, 66, 85)
-    assert img.napari_layer_data.dims == ('C', 'Z', 'Y', 'X')
+    assert img.layer_data.shape == (2, 60, 66, 85)
+    assert img.layer_data.dims == ('C', 'Z', 'Y', 'X')
 
 
 def test_get_layer_data_not_in_memory(resources_dir: Path):
@@ -127,10 +127,10 @@ def test_get_layer_data_not_in_memory(resources_dir: Path):
     import dask
 
     img = nImage(resources_dir / CELLS3D2CH_OME_TIFF)
-    img._load_napari_layer_data(in_memory=False)
-    assert img.napari_layer_data is not None
+    img._load_layer_data(in_memory=False)
+    assert img.layer_data is not None
     # check that the data is a dask array
-    assert isinstance(img.napari_layer_data.data, dask.array.core.Array)
+    assert isinstance(img.layer_data.data, dask.array.core.Array)
 
 
 def test_get_layer_data_tuples_basic(resources_dir: Path):
@@ -233,9 +233,9 @@ def test_get_layer_data_mosaic_tile_in_memory(resources_dir: Path):
             [1, 2, 3]
         )
         img = nImage(resources_dir / CELLS3D2CH_OME_TIFF)
-        img._load_napari_layer_data(in_memory=True)
-        assert img.napari_layer_data is not None
-        assert img.napari_layer_data.shape == (3,)
+        img._load_layer_data(in_memory=True)
+        assert img.layer_data is not None
+        assert img.layer_data.shape == (3,)
 
 
 def test_get_layer_data_mosaic_tile_not_in_memory(
@@ -251,9 +251,9 @@ def test_get_layer_data_mosaic_tile_not_in_memory(
             xr.DataArray([1, 2, 3])
         )
         img = nImage(resources_dir / CELLS3D2CH_OME_TIFF)
-        img._load_napari_layer_data(in_memory=False)
-        assert img.napari_layer_data is not None
-        assert img.napari_layer_data.shape == (3,)
+        img._load_layer_data(in_memory=False)
+        assert img.layer_data is not None
+        assert img.layer_data.shape == (3,)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

I've been long unhappy with the cruft I set up in `nImage`, and I've long been wanting to convert to a cleaner API.
I think I finally am starting to grok `@property` where it can be used effectively as a function to "get" an object, while still accessing it like an attribute. This is a step towards cleaning up the API :)

Second, I've also been wanting to incorporate more axis metadata, and bioio has recently added both `units` and `dimension_properties`. So, this PR uses properties to also add:

1. `axis_labels`
2. `units`

In addition to scale. Speaking of scale, this now contains a bugfix for layers that contain time, woops! the tuple wasn't long enough because it only inherited from physical pixel sizes, and not time. Gah

**I have also made the decision to break the public API here** I have renamed attributes from `napari_scale` to `layer_scale` because it was causing some overlap and redundancy. Now it's more clear that this is getting something for a layer object and not, e.g. a viewer. 

Going forward I promise not to break these objects like this again. Please open an issue if this is a problem, but I know there is not yet much use of this so I can easily make a backwards compatible patch if needed.
